### PR TITLE
Add CF and Sec frameworks on Mac to package_info

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -147,3 +147,6 @@ class CppRestSDKConan(ConanFile):
             self.cpp_info.libs.extend(["winhttp", "httpapi", "bcrypt"])
         if not self.options.shared:
             self.cpp_info.defines.append("_NO_ASYNCRTIMP")
+        if self.settings.os == "Macos":
+            self.cpp_info.exelinkflags.append("-framework CoreFoundation")
+            self.cpp_info.exelinkflags.append("-framework Security")

--- a/conanfile.py
+++ b/conanfile.py
@@ -145,8 +145,10 @@ class CppRestSDKConan(ConanFile):
             self.cpp_info.libs.append("pthread")
         elif self.settings.os == "Windows":
             self.cpp_info.libs.extend(["winhttp", "httpapi", "bcrypt"])
-        if not self.options.shared:
-            self.cpp_info.defines.append("_NO_ASYNCRTIMP")
-        if self.settings.os == "Macos":
+        elif self.settings.os == "Macos":
             self.cpp_info.exelinkflags.append("-framework CoreFoundation")
             self.cpp_info.exelinkflags.append("-framework Security")
+            self.cpp_info.sharedlinkflags.append("-framework CoreFoundation")
+            self.cpp_info.sharedlinkflags.append("-framework Security")
+        if not self.options.shared:
+            self.cpp_info.defines.append("_NO_ASYNCRTIMP")


### PR DESCRIPTION
I would like to make this change for Macs. It is required for the client side. I considered adding options for this. Please let me know if you would like me to alter this.